### PR TITLE
Avoid 16-concurrent-connection cap when reusing a LitleOnline object.

### DIFF
--- a/src/com/litle/sdk/Communication.java
+++ b/src/com/litle/sdk/Communication.java
@@ -13,12 +13,12 @@ import org.apache.cxf.helpers.IOUtils;
 
 public class Communication {
 
-    	private HttpClient httpclient;
-        
-        public Communication() {
-            httpclient = new HttpClient();
-        }
-        
+	private HttpClient httpclient;
+
+	public Communication() {
+		httpclient = new HttpClient();
+	}
+
 	public String requestToServer(String xmlRequest, Properties configuration) {
 		String xmlResponse = null;
 		String proxyHost = configuration.getProperty("proxyHost");


### PR DESCRIPTION
Communication objects now contain an HttpClient object that it reuses with each requestToServer. This makes repeated requests much faster due to reusing an existing HTTP connection. This also prevents reusing the same Communication object from hitting Litle's 16-concurrent-connection cap.
