### PR TITLE
Create missing folders when building with ant

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -118,6 +118,9 @@
 
 	<target name="test" depends="dist">
 		<mkdir dir="${bin}/test" />
+		<mkdir dir="reports/unit" />
+		<mkdir dir="reports/functional" />
+		<mkdir dir="reports/certification" />
 		<javac destdir="${bin}/test" includeantruntime="false" source="1.5" target="1.5" classpathref="classpath.ref"
 			debug="true" debuglevel="lines, vars, source">
 			<compilerarg value="-Xbootclasspath/p:${toString:lib.path.ref}" />
@@ -299,5 +302,6 @@
 		<delete dir="${generated}" />
 		<delete dir="dist" />
 		<delete dir="kit"/>
+		<delete dir="reports" />
 	</target>
 </project>


### PR DESCRIPTION
The following folders were missing and would cause the test target to fail on my machine:
- reports/unit
- reports/functional
- reports/certification
