### PR TITLE
check for litle property file in the resource directory

### DIFF
--- a/src/com/litle/sdk/Configuration.java
+++ b/src/com/litle/sdk/Configuration.java
@@ -13,11 +13,15 @@ public class Configuration {
 				file = new File(System.getProperty("LITLE_CONFIG_DIR") + File.separator + LITLE_SDK_CONFIG);
 			}
 		}
-		else {
-			if(System.getenv("LITLE_CONFIG_DIR") != null) {
+		else if(System.getenv("LITLE_CONFIG_DIR") != null) {
 				file = new File(System.getenv("LITLE_CONFIG_DIR") + File.separator + LITLE_SDK_CONFIG);
-			}
 		}
+        else {
+        	if (getClass().getClassLoader().getResource(LITLE_SDK_CONFIG) != null) {
+            	String filePath = getClass().getClassLoader().getResource(LITLE_SDK_CONFIG).getPath();
+            	file = new File(filePath);
+            }
+        }
 		return file;
 	}
 }


### PR DESCRIPTION
This proposed change is to enable the .litle_SDK_config.properties file to be placed and automatically read from a resource directory. The class still first checks for the file in the home directory or the environment variable path as before. 

We thought this would be useful so we can commit the .litle_SDK_config.properties file within our project one time without additional configuration during initial setup with other developers on the team.  
