### PR TITLE
check for litle property file in the resource directory

### DIFF
--- a/src/com/litle/sdk/Configuration.java
+++ b/src/com/litle/sdk/Configuration.java
@@ -13,15 +13,19 @@ public class Configuration {
 				file = new File(System.getProperty("LITLE_CONFIG_DIR") + File.separator + LITLE_SDK_CONFIG);
 			}
 		}
-		else if(System.getenv("LITLE_CONFIG_DIR") != null) {
-				file = new File(System.getenv("LITLE_CONFIG_DIR") + File.separator + LITLE_SDK_CONFIG);
+		else {
+			if(System.getenv("LITLE_CONFIG_DIR") != null) {
+				if(System.getenv("LITLE_CONFIG_DIR").equals("classpath:.litle_SDK_config.properties")) {
+					if (getClass().getClassLoader().getResource(LITLE_SDK_CONFIG) != null) {
+						String filePath = getClass().getClassLoader().getResource(LITLE_SDK_CONFIG).getPath();
+						file = new File(filePath);
+					}
+				}
+				else {
+					file = new File(System.getenv("LITLE_CONFIG_DIR") + File.separator + LITLE_SDK_CONFIG);
+				}
+			}
 		}
-        else {
-        	if (getClass().getClassLoader().getResource(LITLE_SDK_CONFIG) != null) {
-            	String filePath = getClass().getClassLoader().getResource(LITLE_SDK_CONFIG).getPath();
-            	file = new File(filePath);
-            }
-        }
 		return file;
 	}
 }


### PR DESCRIPTION
Modified Configuration.java to read .litle_SDK_config.properties from the classloader resource path ONLY if 
LITLE_CONFIG_DIR=classpath:.litle_SDK_config.properties.

The main benefit is working in a development environment you will have the option to change the properties in one place.
