### PR TITLE
#41 - Java 7 support

### DIFF
--- a/src/main/java/com/litle/sdk/Communication.java
+++ b/src/main/java/com/litle/sdk/Communication.java
@@ -22,15 +22,52 @@ import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.Session;
 import com.jcraft.jsch.SftpException;
+import java.security.GeneralSecurityException;
+import javax.net.ssl.SSLContext;
+import org.apache.http.conn.ClientConnectionManager;
+import org.apache.http.conn.scheme.Scheme;
+import org.apache.http.conn.scheme.SchemeRegistry;
+import org.apache.http.conn.ssl.SSLSocketFactory;
+import org.apache.http.impl.conn.BasicClientConnectionManager;
 
 public class Communication {
+	private static final String[] SUPPORTED_PROTOCOLS = new String[] {"TLSv1.1", "TLSv1.2"};
 
 	private DefaultHttpClient httpclient;
 	private StreamData streamData;
 
 	public Communication() {
-		httpclient = new DefaultHttpClient();
+		DefaultHttpClient temp = new DefaultHttpClient();
+		try {
+			if (getBestProtocol(SSLContext.getDefault().getDefaultSSLParameters().getProtocols()) == null) {
+				String protocol = getBestProtocol(SSLContext.getDefault().getSupportedSSLParameters().getProtocols());
+				if (protocol == null) {
+					throw new IllegalStateException("No supported TLS protocols available");
+				}
+				SchemeRegistry reg = new SchemeRegistry();
+				SSLContext ctx = SSLContext.getInstance(protocol);
+				ctx.init(null, null, null);
+				reg.register(new Scheme("https", 443, new SSLSocketFactory(ctx)));
+				ClientConnectionManager manager = new BasicClientConnectionManager(reg);
+				temp = new DefaultHttpClient(manager);
+			}
+		} catch (GeneralSecurityException ex) {
+		    throw new IllegalStateException(ex);
+		}
+		httpclient = temp;
 		streamData = new StreamData();
+	}
+	
+	private static String getBestProtocol(final String[] availableProtocols) {
+		for (int i = 0; i < availableProtocols.length; ++i) {
+			// Assuming best protocol is at end
+			for (int j = SUPPORTED_PROTOCOLS.length - 1; j >= 0; --j) {
+				if (SUPPORTED_PROTOCOLS[j].equals(availableProtocols[i])) {
+					return availableProtocols[i];
+				}
+			}
+		}
+		return null;
 	}
 
 	public String requestToServer(String xmlRequest, Properties configuration) {


### PR DESCRIPTION
Java 7 ships with TLS1.1+ support but disabled by default.  Communication
has been updated to detect if there are no default protocols that are
supported by the server.  If this is the case, the JVM supported
protocols are checked and the best is used to initialize the
DefaultHttpClient