### PR TITLE
Bugfix windows file names

### DIFF
--- a/src/main/java/com/litle/sdk/LitleBatchRequest.java
+++ b/src/main/java/com/litle/sdk/LitleBatchRequest.java
@@ -89,8 +89,8 @@ public class LitleBatchRequest {
 		if(!tmpFile.exists()) {
 			tmpFile.mkdir();
 		}
-		java.util.Date date= new java.util.Date();
-		filePath = new String(lbfr.getConfig().getProperty("batchRequestFolder")+ "/tmp/Transactions" +merchantId + new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss.SSS").format(new java.util.Date()));
+		String dateString = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss.SSS").format(new java.util.Date());
+		filePath = new String(lbfr.getConfig().getProperty("batchRequestFolder")+ "/tmp/Transactions" + merchantId + dateString);
 		numOfTxn = 0;
 		try {
 			this.jc = JAXBContext.newInstance("com.litle.sdk.generate");

--- a/src/main/java/com/litle/sdk/LitleBatchRequest.java
+++ b/src/main/java/com/litle/sdk/LitleBatchRequest.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.math.BigInteger;
 import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBElement;
@@ -89,7 +90,7 @@ public class LitleBatchRequest {
 			tmpFile.mkdir();
 		}
 		java.util.Date date= new java.util.Date();
-		filePath = new String(lbfr.getConfig().getProperty("batchRequestFolder")+ "/tmp/Transactions" +merchantId + new Timestamp(date.getTime()));
+		filePath = new String(lbfr.getConfig().getProperty("batchRequestFolder")+ "/tmp/Transactions" +merchantId + new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss.SSS").format(new java.util.Date()));
 		numOfTxn = 0;
 		try {
 			this.jc = JAXBContext.newInstance("com.litle.sdk.generate");


### PR DESCRIPTION
Remove unallowed characters from Batch File names for Windows compatibility.
For example 'Transactions1234562015-10-29 12:40:40.377'
would be 'Transactions1234562015-10-29_12-40-40.377'